### PR TITLE
New functions to expose Errors from Connection Pool and LetterId from RabbitService

### DIFF
--- a/v2/pkg/tcr/connectionpool.go
+++ b/v2/pkg/tcr/connectionpool.go
@@ -29,7 +29,7 @@ func (cp *ConnectionPool) forwardError(err error) {
 	go func() { cp.errors <- err }()
 }
 
-// Errors yields all the internal errs for creating connections.
+// Errors yields all the internal errors for connection pool.
 func (cp *ConnectionPool) Errors() <-chan error {
 	return cp.errors
 }

--- a/v2/pkg/tcr/connectionpool.go
+++ b/v2/pkg/tcr/connectionpool.go
@@ -29,6 +29,11 @@ func (cp *ConnectionPool) forwardError(err error) {
 	go func() { cp.errors <- err }()
 }
 
+// Errors yields all the internal errs for creating connections.
+func (cp *ConnectionPool) Errors() <-chan error {
+	return cp.errors
+}
+
 // NewConnectionPool creates hosting structure for the ConnectionPool.
 func NewConnectionPool(config *PoolConfig) (*ConnectionPool, error) {
 

--- a/v2/pkg/tcr/consumer.go
+++ b/v2/pkg/tcr/consumer.go
@@ -260,7 +260,9 @@ func (con *Consumer) processDeliveries(deliveryChan <-chan amqp.Delivery, chanHo
 				delivery.Body,
 				delivery.Headers,
 				delivery.DeliveryTag,
-				chanHost.Channel)
+				chanHost.Channel,
+				delivery.CorrelationId,
+			)
 
 			if action != nil {
 				action(msg)

--- a/v2/pkg/tcr/letter.go
+++ b/v2/pkg/tcr/letter.go
@@ -12,13 +12,14 @@ type Letter struct {
 
 // Envelope contains all the address details of where a letter is going.
 type Envelope struct {
-	Exchange     string
-	RoutingKey   string
-	ContentType  string
-	Mandatory    bool
-	Immediate    bool
-	Headers      amqp.Table
-	DeliveryMode uint8
+	Exchange      string
+	RoutingKey    string
+	ContentType   string
+	Mandatory     bool
+	Immediate     bool
+	Headers       amqp.Table
+	DeliveryMode  uint8
+	CorrelationId string
 }
 
 // WrappedBody is to go inside a Letter struct with indications of the body of data being modified (ex., compressed).

--- a/v2/pkg/tcr/message.go
+++ b/v2/pkg/tcr/message.go
@@ -27,11 +27,12 @@ func (not *PublishReceipt) ToString() string {
 
 // ReceivedMessage allow for you to acknowledge, after processing the received payload, by its RabbitMQ tag and Channel pointer.
 type ReceivedMessage struct {
-	IsAckable   bool
-	Body        []byte
-	Headers     amqp.Table
-	deliveryTag uint64
-	amqpChan    *amqp.Channel
+	IsAckable     bool
+	Body          []byte
+	Headers       amqp.Table
+	deliveryTag   uint64
+	amqpChan      *amqp.Channel
+	CorrelationId string
 }
 
 // NewMessage creates a new Message.
@@ -40,14 +41,16 @@ func NewMessage(
 	body []byte,
 	headers amqp.Table,
 	deliveryTag uint64,
-	amqpChan *amqp.Channel) *ReceivedMessage {
+	amqpChan *amqp.Channel,
+	correlationId string) *ReceivedMessage {
 
 	return &ReceivedMessage{
-		IsAckable:   isAckable,
-		Body:        body,
-		Headers:     headers,
-		deliveryTag: deliveryTag,
-		amqpChan:    amqpChan,
+		IsAckable:     isAckable,
+		Body:          body,
+		Headers:       headers,
+		deliveryTag:   deliveryTag,
+		amqpChan:      amqpChan,
+		CorrelationId: correlationId,
 	}
 }
 

--- a/v2/pkg/tcr/publisher.go
+++ b/v2/pkg/tcr/publisher.go
@@ -81,10 +81,11 @@ func (pub *Publisher) Publish(letter *Letter, skipReceipt bool) {
 		letter.Envelope.Mandatory,
 		letter.Envelope.Immediate,
 		amqp.Publishing{
-			ContentType:  letter.Envelope.ContentType,
-			Body:         letter.Body,
-			Headers:      letter.Envelope.Headers,
-			DeliveryMode: letter.Envelope.DeliveryMode,
+			ContentType:   letter.Envelope.ContentType,
+			Body:          letter.Body,
+			Headers:       letter.Envelope.Headers,
+			DeliveryMode:  letter.Envelope.DeliveryMode,
+			CorrelationId: letter.Envelope.CorrelationId,
 		},
 	)
 
@@ -114,10 +115,11 @@ func (pub *Publisher) PublishWithTransient(letter *Letter) error {
 		letter.Envelope.Mandatory,
 		letter.Envelope.Immediate,
 		amqp.Publishing{
-			ContentType:  letter.Envelope.ContentType,
-			Body:         letter.Body,
-			Headers:      letter.Envelope.Headers,
-			DeliveryMode: letter.Envelope.DeliveryMode,
+			ContentType:   letter.Envelope.ContentType,
+			Body:          letter.Body,
+			Headers:       letter.Envelope.Headers,
+			DeliveryMode:  letter.Envelope.DeliveryMode,
+			CorrelationId: letter.Envelope.CorrelationId,
 		},
 	)
 }
@@ -145,10 +147,11 @@ func (pub *Publisher) PublishWithConfirmation(letter *Letter, timeout time.Durat
 			letter.Envelope.Mandatory,
 			letter.Envelope.Immediate,
 			amqp.Publishing{
-				ContentType:  letter.Envelope.ContentType,
-				Body:         letter.Body,
-				Headers:      letter.Envelope.Headers,
-				DeliveryMode: letter.Envelope.DeliveryMode,
+				ContentType:   letter.Envelope.ContentType,
+				Body:          letter.Body,
+				Headers:       letter.Envelope.Headers,
+				DeliveryMode:  letter.Envelope.DeliveryMode,
+				CorrelationId: letter.Envelope.CorrelationId,
 			},
 		)
 		if err != nil {
@@ -201,10 +204,11 @@ func (pub *Publisher) PublishWithConfirmationContext(ctx context.Context, letter
 			letter.Envelope.Mandatory,
 			letter.Envelope.Immediate,
 			amqp.Publishing{
-				ContentType:  letter.Envelope.ContentType,
-				Body:         letter.Body,
-				Headers:      letter.Envelope.Headers,
-				DeliveryMode: letter.Envelope.DeliveryMode,
+				ContentType:   letter.Envelope.ContentType,
+				Body:          letter.Body,
+				Headers:       letter.Envelope.Headers,
+				DeliveryMode:  letter.Envelope.DeliveryMode,
+				CorrelationId: letter.Envelope.CorrelationId,
 			},
 		)
 		if err != nil {
@@ -264,10 +268,11 @@ func (pub *Publisher) PublishWithConfirmationTransient(letter *Letter, timeout t
 			letter.Envelope.Mandatory,
 			letter.Envelope.Immediate,
 			amqp.Publishing{
-				ContentType:  letter.Envelope.ContentType,
-				Body:         letter.Body,
-				Headers:      letter.Envelope.Headers,
-				DeliveryMode: letter.Envelope.DeliveryMode,
+				ContentType:   letter.Envelope.ContentType,
+				Body:          letter.Body,
+				Headers:       letter.Envelope.Headers,
+				DeliveryMode:  letter.Envelope.DeliveryMode,
+				CorrelationId: letter.Envelope.CorrelationId,
 			},
 		)
 		if err != nil {

--- a/v2/pkg/tcr/rabbitservice.go
+++ b/v2/pkg/tcr/rabbitservice.go
@@ -119,7 +119,7 @@ func (rs *RabbitService) createConsumers(consumerConfigs map[string]*ConsumerCon
 // PublishWithConfirmation tries to publish and wait for a confirmation.
 func (rs *RabbitService) PublishWithConfirmation(
 	input interface{},
-	exchangeName, routingKey, metadata string,
+	exchangeName, routingKey, metadata, correlationId string,
 	wrapPayload bool,
 	headers amqp.Table) error {
 
@@ -155,13 +155,14 @@ func (rs *RabbitService) PublishWithConfirmation(
 			LetterID: currentCount,
 			Body:     data,
 			Envelope: &Envelope{
-				Exchange:     exchangeName,
-				RoutingKey:   routingKey,
-				ContentType:  "application/json",
-				Mandatory:    false,
-				Immediate:    false,
-				DeliveryMode: 2,
-				Headers:      headers,
+				Exchange:      exchangeName,
+				RoutingKey:    routingKey,
+				ContentType:   "application/json",
+				Mandatory:     false,
+				Immediate:     false,
+				DeliveryMode:  2,
+				Headers:       headers,
+				CorrelationId: correlationId,
 			},
 		},
 		time.Duration(time.Millisecond*300))
@@ -172,7 +173,7 @@ func (rs *RabbitService) PublishWithConfirmation(
 // Publish tries to publish directly without retry and data optionally wrapped in a ModdedLetter.
 func (rs *RabbitService) Publish(
 	input interface{},
-	exchangeName, routingKey, metadata string,
+	exchangeName, routingKey, metadata, correlationId string,
 	wrapPayload bool,
 	headers amqp.Table) error {
 
@@ -206,12 +207,13 @@ func (rs *RabbitService) Publish(
 			LetterID: currentCount,
 			Body:     data,
 			Envelope: &Envelope{
-				Exchange:     exchangeName,
-				RoutingKey:   routingKey,
-				ContentType:  "application/json",
-				Mandatory:    false,
-				Immediate:    false,
-				DeliveryMode: 2,
+				Exchange:      exchangeName,
+				RoutingKey:    routingKey,
+				ContentType:   "application/json",
+				Mandatory:     false,
+				Immediate:     false,
+				DeliveryMode:  2,
+				CorrelationId: correlationId,
 			},
 		},
 		false)
@@ -222,7 +224,7 @@ func (rs *RabbitService) Publish(
 // PublishData tries to publish.
 func (rs *RabbitService) PublishData(
 	data []byte,
-	exchangeName, routingKey string,
+	exchangeName, routingKey, correlationId string,
 	headers amqp.Table) error {
 
 	if rs.shutdown {
@@ -241,13 +243,14 @@ func (rs *RabbitService) PublishData(
 			LetterID: currentCount,
 			Body:     data,
 			Envelope: &Envelope{
-				Exchange:     exchangeName,
-				RoutingKey:   routingKey,
-				ContentType:  "application/json",
-				Mandatory:    false,
-				Immediate:    false,
-				DeliveryMode: 2,
-				Headers:      headers,
+				Exchange:      exchangeName,
+				RoutingKey:    routingKey,
+				ContentType:   "application/json",
+				Mandatory:     false,
+				Immediate:     false,
+				DeliveryMode:  2,
+				Headers:       headers,
+				CorrelationId: correlationId,
 			},
 		},
 		false)

--- a/v2/pkg/tcr/rabbitservice.go
+++ b/v2/pkg/tcr/rabbitservice.go
@@ -458,3 +458,11 @@ ProcessLoop:
 		}
 	}
 }
+
+// Generate new letter id based on letterCount
+func (rs *RabbitService) GetNewLetterID() uint64 {
+	currentCount := atomic.LoadUint64(&rs.letterCount)
+	atomic.AddUint64(&rs.letterCount, 1)
+
+	return currentCount
+}


### PR DESCRIPTION
Hi, this is a great RabbitMQ library, we are looking at deploying it to production.

Meanwhile, we have a scenario which requires to extend your library to support synchronized publish with confirmation. We plan to do the extension at our side first. However, we need 2 additional public functions from Connection Pool and Rabbit Service. 

- ConnectionPool.Errors() to expose the error raised internally to support logging and tracing
- RabbitService.GetNewLetterID() to expose the letter id counter for external extension methods but also keep the letter id logic within the RabbitService to keep the id synced all the time.