### PR TITLE
Publisher creation (without a Config) has nil for the object when used in AutoPublisher / Deliver Letters.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/houseofcat/turbocookedrabbit
+module github.com/stoex/turbocookedrabbit
 
 go 1.14

--- a/v1/go.mod
+++ b/v1/go.mod
@@ -1,4 +1,4 @@
-module github.com/houseofcat/turbocookedrabbit
+module github.com/stoex/turbocookedrabbit
 
 go 1.14
 

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,4 +1,4 @@
-module github.com/houseofcat/turbocookedrabbit/v2
+module github.com/stoex/turbocookedrabbit/v2
 
 go 1.14
 

--- a/v2/pkg/tcr/publisher.go
+++ b/v2/pkg/tcr/publisher.go
@@ -350,7 +350,7 @@ AutoPublishLoop:
 func (pub *Publisher) deliverLetters() bool {
 
 	// Allow parallel publishing with transient channels.
-	parallelPublishSemaphore := make(chan struct{}, pub.Config.PoolConfig.MaxCacheChannelCount/2+1)
+	parallelPublishSemaphore := make(chan struct{}, pub.ConnectionPool.Config.MaxCacheChannelCount/2+1)
 
 	for {
 


### PR DESCRIPTION
This fixes a potential nil pointer dereference - it's safer to use the ConnectionPool.Config since that should always be there.