### PR TITLE
Acquire lock before fetch Started, to prevent data-race

### DIFF
--- a/v2/pkg/tcr/consumer.go
+++ b/v2/pkg/tcr/consumer.go
@@ -360,5 +360,7 @@ FlushLoop:
 
 // Started allows you to determine if a consumer has started.
 func (con *Consumer) Started() bool {
+	con.conLock.Lock()
+	defer con.conLock.Unlock()
 	return con.started
 }


### PR DESCRIPTION
Hi, now i am working on library which are rely on this. I want to close all my library channels only after consumer really stop consuming loop. For example:
```go
err := consuming.consumer.StopConsuming(immediately, flushMessages)
if err != nil {
	return errors.WithMessage(err, "stop consumer")
}

// NOTE: do not close output channel while underlying consumer really stops
for consuming.consumer.Started() {
	time.Sleep(10 * time.Millisecond)
}

close(consuming.outputChan)
```

And now, when i run tests, i've got a data-race, because i want to read variable Started, and at the same time this variable changed by consumer.
